### PR TITLE
xml document 구현 부분을 xml serialization으로 변경

### DIFF
--- a/src/TableCloth/Models/SandboxConfiguration.cs
+++ b/src/TableCloth/Models/SandboxConfiguration.cs
@@ -1,15 +1,140 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Xml;
+using System.Xml.Serialization;
 
 namespace TableCloth.Models
 {
-	[Serializable]
+    [Serializable]
     public sealed class SandboxConfiguration
-	{
-		public X509CertPair CertPair { get; init; }
-		public bool EnableMicrophone { get; init; }
-		public bool EnableWebCam { get; init; }
-		public bool EnablePrinters { get; init; }
-		public IEnumerable<InternetService> SelectedServices { get; init; }
+    {
+        public X509CertPair CertPair { get; init; }
+        public bool EnableMicrophone { get; init; }
+        public bool EnableWebCam { get; init; }
+        public bool EnablePrinters { get; init; }
+        public ICollection<InternetService> SelectedServices { get; init; }
+
+        public string AssetsDirectoryPath { get; internal set; }
+
+        public string SerializeToXml() => SandboxConfigurationGenerator.SerializeToXml(this);
+    }
+
+    [XmlRoot("Configuration")]
+    public sealed partial class SandboxConfigurationGenerator
+    {
+        internal const string DefaultLogonCommand = @"C:\assets\StartupScript.cmd";
+        internal const string Enable = "Enable";
+        internal const string Disable = "Disable";
+
+        [XmlElement]
+        public string AudioInput { get; set; }
+
+        [XmlElement]
+        public string VideoInput { get; set; }
+
+        [XmlElement]
+        public string PrinterRedirection { get; set; }
+
+        [XmlElement]
+        public string LogonCommand { get; set; } = DefaultLogonCommand;
+
+        [XmlArray, XmlArrayItem(typeof(MappedFolder))]
+        public List<MappedFolder> MappedFolders { get; } = new();
+
+        [Serializable, XmlType]
+        public sealed class MappedFolder
+        {
+            public const string DefaultAssetPath = @"C:\assets";
+
+            [XmlElement]
+            public string HostFolder { get; set; }
+
+            [XmlElement]
+            public string SandboxFolder { get; set; }
+
+            [XmlElement]
+            public string ReadOnly { get; set; } = bool.TrueString;
+        }
+    }
+
+    public partial class SandboxConfigurationGenerator
+    {
+        public sealed class SandboxConfigToXmlWriter : StringWriter
+        {
+            public override Encoding Encoding => Encoding.UTF8;
+        }
+
+        public static string SerializeToXml(SandboxConfiguration config)
+        {
+            var serializer = new XmlSerializer(typeof(SandboxConfigurationGenerator));
+            var @namespace = new XmlSerializerNamespaces(new[] { new XmlQualifiedName(string.Empty) });
+
+            using var contentStream = new SandboxConfigToXmlWriter();
+
+            serializer.Serialize(contentStream, Create(config), @namespace);
+
+            return contentStream.ToString();
+        }
+
+        public static SandboxConfigurationGenerator Create(SandboxConfiguration config)
+        {
+            var generator = new SandboxConfigurationGenerator
+            {
+                AudioInput = config.EnableMicrophone ? Enable : Disable,
+                VideoInput = config.EnableWebCam ? Enable : Disable,
+                PrinterRedirection = config.EnablePrinters ? Enable : Disable,
+            };
+
+            generator.SetAssetDirectory(config);
+
+            return generator;
+        }
+        public void SetAssetDirectory(SandboxConfiguration config)
+        {
+            if (!Directory.Exists(config.AssetsDirectoryPath))
+                return;
+
+            MappedFolders.Clear();
+
+            MappedFolders.Add(new MappedFolder
+            {
+                HostFolder = config.AssetsDirectoryPath,
+                SandboxFolder = MappedFolder.DefaultAssetPath,
+                ReadOnly = bool.TrueString,
+            });
+
+            if (config.CertPair == null)
+                return;
+
+            var certAssetsDirectoryPath = Path.Combine(config.AssetsDirectoryPath, "certs");
+            if (!Directory.Exists(certAssetsDirectoryPath))
+                Directory.CreateDirectory(certAssetsDirectoryPath);
+
+            var destDerFilePath = Path.Combine(
+                certAssetsDirectoryPath,
+                Path.GetFileName(config.CertPair.DerFilePath));
+
+
+            var destKeyFileName = Path.Combine(
+                certAssetsDirectoryPath,
+                Path.GetFileName(config.CertPair.KeyFilePath));
+
+            File.Copy(config.CertPair.DerFilePath, destDerFilePath, true);
+            File.Copy(config.CertPair.KeyFilePath, destKeyFileName, true);
+
+            var candidatePath = Path.Join("AppData", "LocalLow", "NPKI", config.CertPair.SubjectOrganization);
+            if (config.CertPair.IsPersonalCert)
+                candidatePath = Path.Join(candidatePath, "USER", config.CertPair.SubjectNameForNpkiApp);
+            candidatePath = Path.Join(@"C:\Users\WDAGUtilityAccount", candidatePath);
+
+            MappedFolders.Add(new MappedFolder
+            {
+                HostFolder = certAssetsDirectoryPath,
+                SandboxFolder = candidatePath,
+                ReadOnly = bool.FalseString,
+            });
+        }
     }
 }

--- a/src/TableCloth/SandboxBuilder.cs
+++ b/src/TableCloth/SandboxBuilder.cs
@@ -1,180 +1,74 @@
 ﻿using System;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Xml;
 using TableCloth.Models;
 
 namespace TableCloth
 {
-    static class SandboxBuilder
+    public static class SandboxBuilder
     {
-		public static string GenerateSandboxConfiguration(string outputDirectory, SandboxConfiguration config)
-		{
-			if (config == null)
-				throw new ArgumentNullException(nameof(config));
+        public static string GenerateSandboxConfiguration(string outputDirectory, SandboxConfiguration config)
+        {
+            if (config == null)
+                throw new ArgumentNullException(nameof(config));
 
-			if (!Directory.Exists(outputDirectory))
-				Directory.CreateDirectory(outputDirectory);
+            if (!Directory.Exists(outputDirectory))
+                Directory.CreateDirectory(outputDirectory);
 
-			var assetsDirectory = Path.Combine(outputDirectory, "assets");
-			if (!Directory.Exists(assetsDirectory))
-				Directory.CreateDirectory(assetsDirectory);
+            var assetsDirectory = Path.Combine(outputDirectory, "assets");
+            if (!Directory.Exists(assetsDirectory))
+                Directory.CreateDirectory(assetsDirectory);
 
-			var batchFileContent = GenerateSandboxStartupScript(config);
-			var batchFilePath = Path.Combine(assetsDirectory, "StartupScript.cmd");
-			File.WriteAllText(batchFilePath, batchFileContent, Encoding.Default);
+            var batchFileContent = GenerateSandboxStartupScript(config);
+            var batchFilePath = Path.Combine(assetsDirectory, "StartupScript.cmd");
+            File.WriteAllText(batchFilePath, batchFileContent, Encoding.Default);
 
-			var wsbFileContent = GenerateSandboxSpecDocument(config, assetsDirectory);
-			var wsbFilePath = Path.Combine(outputDirectory, "InternetBankingSandbox.wsb");
-			wsbFileContent.Save(wsbFilePath);
+            config.AssetsDirectoryPath = assetsDirectory;
 
-			return wsbFilePath;
-		}
+            var wsbFilePath = Path.Combine(outputDirectory, "InternetBankingSandbox.wsb");
+            File.WriteAllText(wsbFilePath, config.SerializeToXml());
 
-		public static string GenerateSandboxStartupScript(SandboxConfiguration config)
-		{
-			if (config == null)
-				throw new ArgumentNullException(nameof(config));
+            return wsbFilePath;
+        }
 
-			var buffer = new StringBuilder();
-			var services = config.SelectedServices;
-			var packageTotalCount = services.Sum(x => x.Packages.Count());
-			var siteNameList = string.Join(", ", services.Select(x => x.SiteName));
+        public static string GenerateSandboxStartupScript(SandboxConfiguration config)
+        {
+            if (config == null)
+                throw new ArgumentNullException(nameof(config));
 
-			var infoMessage = $"지금부터 {packageTotalCount}개 프로그램의 설치 과정이 시작됩니다. 모든 프로그램의 설치가 끝나면 자동으로 {siteNameList} 홈페이지가 열립니다.";
-			string value = $@"PowerShell -Command ""Add-Type -AssemblyName System.Windows.Forms;[System.Windows.Forms.MessageBox]::Show('{infoMessage}', '안내', [System.Windows.Forms.MessageBoxButtons]::OK, [System.Windows.Forms.MessageBoxIcon]::Information)""";
-			_ = buffer.AppendLine(value);
+            var buffer = new StringBuilder();
+            var services = config.SelectedServices;
+            var packageTotalCount = services.Sum(x => x.Packages.Count());
+            var siteNameList = string.Join(", ", services.Select(x => x.SiteName));
 
-			string[] homepageUrls = services.Select(x => x.HomepageUrl.AbsoluteUri).ToArray();
+            var infoMessage = $"지금부터 {packageTotalCount}개 프로그램의 설치 과정이 시작됩니다. 모든 프로그램의 설치가 끝나면 자동으로 {siteNameList} 홈페이지가 열립니다.";
+            var value = $@"PowerShell -Command ""Add-Type -AssemblyName System.Windows.Forms;[System.Windows.Forms.MessageBox]::Show('{infoMessage}', '안내', [System.Windows.Forms.MessageBoxButtons]::OK, [System.Windows.Forms.MessageBoxIcon]::Information)""";
+            buffer.AppendLine(value);
 
-			foreach (var eachService in services)
+            foreach (var eachPackage in services.SelectMany(service => service.Packages))
             {
-				foreach (var eachPackage in eachService.Packages)
-				{
-					string localFileName;
-					try { localFileName = Path.GetFileName(eachPackage.PackageDownloadUrl.LocalPath); }
-					catch { localFileName = Guid.NewGuid().ToString("n") + ".exe"; }
+                var localFileName = GetLocalFileName(eachPackage.PackageDownloadUrl.LocalPath);
 
-					_ = buffer.AppendLine($@"REM Run {eachPackage.Name} Setup");
-					_ = buffer.AppendLine($@"curl -L ""{eachPackage.PackageDownloadUrl}"" --output ""%temp%\{localFileName}""");
+                buffer
+                    .AppendLine($@"REM Run {eachPackage.Name} Setup")
+                    .AppendLine($@"curl -L ""{eachPackage.PackageDownloadUrl}"" --output ""%temp%\{localFileName}""")
+                    .AppendLine(!string.IsNullOrWhiteSpace(eachPackage.Arguments)
+                        ? $@"start /abovenormal /wait %temp%\{localFileName} {eachPackage.Arguments}"
+                        : $@"start /abovenormal /wait %temp%\{localFileName}")
+                    .AppendLine();
+            }
 
-					if (!string.IsNullOrWhiteSpace(eachPackage.Arguments))
-						_ = buffer.AppendLine($@"start /abovenormal /wait %temp%\{localFileName} {eachPackage.Arguments}");
-					else
-						_ = buffer.AppendLine($@"start /abovenormal /wait %temp%\{localFileName}");
+            foreach (var eachHomePageUrl in services.Select(x => x.HomepageUrl.AbsoluteUri))
+                buffer.AppendLine($@"start {eachHomePageUrl}");
 
-					_ = buffer.AppendLine();
-				}
-			}
+            return buffer.ToString();
 
-			foreach (var eachHomePageUrl in homepageUrls)
-				_ = buffer.AppendLine($@"start {eachHomePageUrl}");
-
-			return buffer.ToString();
-		}
-
-		public static XmlDocument GenerateSandboxSpecDocument(SandboxConfiguration config, string assetsDirectoryPath)
-		{
-			if (config == null)
-				throw new ArgumentNullException(nameof(config));
-
-			var doc = new XmlDocument();
-			doc.AppendChild(doc.CreateXmlDeclaration("1.0", "utf-8", null));
-			var configurationElem = doc.CreateElement("Configuration");
-			{
-				var audioInputElem = doc.CreateElement("AudioInput");
-				if (config.EnableMicrophone)
-					audioInputElem.InnerText = "Enable";
-				else
-					audioInputElem.InnerText = "Disable";
-				configurationElem.AppendChild(audioInputElem);
-				
-				var videoInputElem = doc.CreateElement("VideoInput");
-				if (config.EnablePrinters)
-					videoInputElem.InnerText = "Enable";
-				else
-					videoInputElem.InnerText = "Disable";
-				configurationElem.AppendChild(videoInputElem);
-
-				var printerRedirectionElem = doc.CreateElement("PrinterRedirection");
-				if (config.EnablePrinters)
-					printerRedirectionElem.InnerText = "Enable";
-				else
-					printerRedirectionElem.InnerText = "Disable";
-				configurationElem.AppendChild(printerRedirectionElem);
-
-				var mappedFoldersElem = doc.CreateElement("MappedFolders");
-				{
-					var mappedFolderElem = doc.CreateElement("MappedFolder");
-					{
-						var hostFolderElem = doc.CreateElement("HostFolder");
-						hostFolderElem.InnerText = assetsDirectoryPath;
-						mappedFolderElem.AppendChild(hostFolderElem);
-
-						var sandboxFolderElem = doc.CreateElement("SandboxFolder");
-						sandboxFolderElem.InnerText = @"C:\assets";
-						mappedFolderElem.AppendChild(sandboxFolderElem);
-
-						var readOnlyElem = doc.CreateElement("ReadOnly");
-						readOnlyElem.InnerText = Boolean.TrueString.ToString();
-						mappedFolderElem.AppendChild(readOnlyElem);
-					}
-					mappedFoldersElem.AppendChild(mappedFolderElem);
-
-					if (config.CertPair != null)
-					{
-						var mappedNpkiFolderElem = doc.CreateElement("MappedFolder");
-						{
-							var certAssetsDirectoryPath = Path.Combine(assetsDirectoryPath, "certs");
-							if (!Directory.Exists(certAssetsDirectoryPath))
-								Directory.CreateDirectory(certAssetsDirectoryPath);
-
-							var destDerFilePath = Path.Combine(
-								certAssetsDirectoryPath,
-								Path.GetFileName(config.CertPair.DerFilePath));
-							File.Copy(config.CertPair.DerFilePath, destDerFilePath, true);
-
-							var destKeyFileName = Path.Combine(
-								certAssetsDirectoryPath,
-								Path.GetFileName(config.CertPair.KeyFilePath));
-							File.Copy(config.CertPair.KeyFilePath, destKeyFileName, true);
-
-							var hostFolderElem = doc.CreateElement("HostFolder");
-							hostFolderElem.InnerText = certAssetsDirectoryPath;
-							mappedNpkiFolderElem.AppendChild(hostFolderElem);
-
-							var candidatePath = Path.Join("AppData", "LocalLow", "NPKI", config.CertPair.SubjectOrganization);
-							if (config.CertPair.IsPersonalCert)
-								candidatePath = Path.Join(candidatePath, "USER", config.CertPair.SubjectNameForNpkiApp);
-							candidatePath = Path.Join(@"C:\Users\WDAGUtilityAccount", candidatePath);
-
-							var sandboxFolderElem = doc.CreateElement("SandboxFolder");
-							sandboxFolderElem.InnerText = candidatePath;
-
-							mappedNpkiFolderElem.AppendChild(sandboxFolderElem);
-
-							var readOnlyElem = doc.CreateElement("ReadOnly");
-							readOnlyElem.InnerText = Boolean.FalseString.ToString();
-							mappedNpkiFolderElem.AppendChild(readOnlyElem);
-						}
-						mappedFoldersElem.AppendChild(mappedNpkiFolderElem);
-					}
-				}
-				configurationElem.AppendChild(mappedFoldersElem);
-
-				var logonCommandElem = doc.CreateElement("LogonCommand");
-				{
-					var commandElem = doc.CreateElement("Command");
-					commandElem.InnerText = @"C:\assets\StartupScript.cmd";
-					logonCommandElem.AppendChild(commandElem);
-				}
-				configurationElem.AppendChild(logonCommandElem);
-			}
-			doc.AppendChild(configurationElem);
-
-			return doc;
-		}
-	}
+            static string GetLocalFileName(string localPath)
+            {
+                try { return Path.GetFileName(localPath); }
+                catch { return $"{Guid.NewGuid():N}.exe"; }
+            }
+        }
+    }
 }

--- a/src/TableCloth/X509CertPair.cs
+++ b/src/TableCloth/X509CertPair.cs
@@ -6,65 +6,64 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace TableCloth
 {
-    public sealed class X509CertPair
+    public sealed partial class X509CertPair
     {
-		public static IEnumerable<X509CertPair> ScanX509CertPairs()
-		{
-			var list = new List<X509CertPair>();
-            var directoryCandidates = new List<string>
-            {
-                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "AppData", "LocalLow", "NPKI"),
-            };
-
-            foreach (var eachDrive in DriveInfo.GetDrives())
-			{
-				if (eachDrive.DriveType != DriveType.Removable)
-					continue;
-
-				directoryCandidates.Add(eachDrive.RootDirectory.FullName);
-			}
-
-			foreach (var eachDirectoryCandidate in directoryCandidates)
-				if (Directory.Exists(eachDirectoryCandidate))
-					list.AddRange(ScanX509CertPairs(eachDirectoryCandidate));
-
-			return list.ToArray();
-		}
-
-		// https://stackoverflow.com/questions/5098011/directory-enumeratefiles-unauthorizedaccessexception
-		public static IEnumerable<X509CertPair> ScanX509CertPairs(string rootPath)
-		{
-			var foundFiles = Enumerable.Empty<X509CertPair>();
-
-			try
-			{
-				IEnumerable<string> subDirs = Directory.EnumerateDirectories(rootPath);
-				foreach (string dir in subDirs)
-				{
-					// Add files in subdirectories recursively to the list
-					foundFiles = foundFiles.Concat(ScanX509CertPairs(dir));
-				}
-			}
-			catch (UnauthorizedAccessException) { }
-			catch (PathTooLongException) { }
-
-			try
-			{
-				// Add files from the current directory
-				var singleDerFile = Directory.EnumerateFiles(rootPath, "*.der").FirstOrDefault();
-				var singleKeyFile = Directory.EnumerateFiles(rootPath, "*.key").FirstOrDefault();
-
-				if (File.Exists(singleDerFile) && File.Exists(singleKeyFile))
-					foundFiles = foundFiles.Concat(new X509CertPair[] { CreateX509CertPair(singleDerFile, singleKeyFile) });
-			}
-			catch (UnauthorizedAccessException) { }
-
-			return foundFiles;
-		}
-
-		public static X509CertPair CreateX509CertPair(string derFilePath, string keyFilePath)
+        public static IEnumerable<X509CertPair> ScanX509CertPairs()
         {
-			if (!File.Exists(derFilePath))
+            var defaultNpkiPath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "AppData", "LocalLow", "NPKI");
+
+            var directoryCandidates = new List<string> {defaultNpkiPath};
+
+            var usbDrives = DriveInfo.GetDrives()
+                .Where(d => d.DriveType == DriveType.Removable)
+                .Select(d => d.RootDirectory.FullName);
+
+            directoryCandidates.AddRange(usbDrives);
+
+            return directoryCandidates.Where(Directory.Exists).SelectMany(ScanX509CertPairs);
+
+        }
+
+        // https://stackoverflow.com/questions/5098011/directory-enumeratefiles-unauthorizedaccessexception
+        public static ICollection<X509CertPair> ScanX509CertPairs(string rootPath)
+        {
+            var foundFiles = new List<X509CertPair>();
+
+            try
+            {
+                foreach (var dir in Directory.EnumerateDirectories(rootPath))
+                {
+                    // Add files in subdirectories recursively to the list
+                    foundFiles.AddRange(ScanX509CertPairs(dir));
+                }
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+            catch (PathTooLongException)
+            {
+            }
+
+            try
+            {
+                // Add files from the current directory
+                var singleDerFile = Directory.EnumerateFiles(rootPath, "*.der").FirstOrDefault();
+                var singleKeyFile = Directory.EnumerateFiles(rootPath, "*.key").FirstOrDefault();
+
+                if (File.Exists(singleDerFile) && File.Exists(singleKeyFile))
+                    foundFiles.Add(CreateX509CertPair(singleDerFile, singleKeyFile));
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+
+            return foundFiles;
+        }
+
+        public static X509CertPair CreateX509CertPair(string derFilePath, string keyFilePath)
+        {
+            if (!File.Exists(derFilePath))
                 throw new FileNotFoundException("Certification file (.der) does not exists.", derFilePath);
 
             if (!File.Exists(keyFilePath))
@@ -77,25 +76,27 @@ namespace TableCloth
                 .Split(',', StringSplitOptions.RemoveEmptyEntries)
                 .Select(x =>
                 {
-                    var parts = x.Trim().Split('=', StringSplitOptions.None);
+                    var parts = x.Trim().Split('=');
                     var unitName = parts.ElementAtOrDefault(0)?.Trim() ?? string.Empty;
                     var value = parts.ElementAtOrDefault(1)?.Trim() ?? string.Empty;
                     return new KeyValuePair<string, string>(unitName, value);
-                });
+                })
+                .ToArray();
+
             var organizationName = subjectNamePairs
                 .Where(x => string.Equals(x.Key, "o", StringComparison.InvariantCultureIgnoreCase))
                 .Select(x => x.Value)
                 .FirstOrDefault();
-            var usageExtension = cert.Extensions
-                .Cast<X509Extension>()
-                .Where(x => x is X509KeyUsageExtension)
-                .Select(x => x as X509KeyUsageExtension)
-                .FirstOrDefault();
-            var isPersonalCert = usageExtension != null &&
-                usageExtension.KeyUsages.HasFlag(X509KeyUsageFlags.NonRepudiation) &&
-                usageExtension.KeyUsages.HasFlag(X509KeyUsageFlags.DigitalSignature);
 
-            return new X509CertPair()
+            var usageExtension = cert.Extensions
+                .OfType<X509KeyUsageExtension>()
+                .FirstOrDefault();
+
+            var isPersonalCert = usageExtension != null &&
+                                 usageExtension.KeyUsages.HasFlag(X509KeyUsageFlags.NonRepudiation) &&
+                                 usageExtension.KeyUsages.HasFlag(X509KeyUsageFlags.DigitalSignature);
+
+            return new X509CertPair
             {
                 Subject = subjectNamePairs.ToArray(),
                 IsPersonalCert = isPersonalCert,
@@ -103,8 +104,11 @@ namespace TableCloth
                 KeyFilePath = keyFilePath,
             };
         }
+    }
 
-		private X509CertPair() { }
+    public partial class X509CertPair
+    {
+        private X509CertPair() { }
 
         public string DerFilePath { get; init; }
         public string KeyFilePath { get; init; }


### PR DESCRIPTION
xml document 구현 부분을 xml serialization으로 변경하였습니다.

변경한 이유는 추가/확장시 좀 더 편리하게 스크립트를 생산하기 위함이며,
아래와 같은 문제점을 최소화하기 위함입니다.

```cs
var videoInputElem = doc.CreateElement("VideoInput");
if (config.EnablePrinters) // VoiceInput인데 분기문에는 EnablePrinters 속성으로 확인하는 문제가 있음
	videoInputElem.InnerText = "Enable";
else
	videoInputElem.InnerText = "Disable";
configurationElem.AppendChild(videoInputElem);
```